### PR TITLE
Fix chart.js URL in samples

### DIFF
--- a/samples/utils.js
+++ b/samples/utils.js
@@ -1,7 +1,7 @@
 'use strict';
 
 (function(Utils) {
-	const chartjsUrl = 'https://cdn.jsdelivr.net/npm/chart.js@next/dist/chart.js';
+	const chartjsUrl = 'https://cdn.jsdelivr.net/npm/chart.js@3.2.1/dist/chart.js';
 	const localUrl = '../dist/chartjs-chart-sankey.js';
 	const remoteUrl = 'https://cdn.jsdelivr.net/npm/chartjs-chart-sankey/dist/chartjs-chart-sankey.js';
 


### PR DESCRIPTION
Currently, when I try to visualize samples locally, I've got an error:

> Error loading chartjs-chart-sankey

It's because the samples try to fetch the `beta` version of chart.js from jsdelivr. So this PR fixes the chart.js URL.