### PR TITLE
Values and Units of Measurement

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,10 @@ const chart = new Chart(ctx, {
         a: 'Label A',
         b: 'Label B',
         c: 'Label C'
-      }
+      },
+      /* optional properties */
+      showValues: true,
+      unitOfMeasure: "kW"
     }]
   },
 });

--- a/src/controller.js
+++ b/src/controller.js
@@ -203,7 +203,12 @@ export default class SankeyController extends DatasetController {
       const y = yScale.getPixelForValue(node.y);
       const max = Math.max(node.in, node.out);
       const height = Math.abs(yScale.getPixelForValue(node.y + max) - y);
-      const label = labels && labels[node.key] || node.key;
+      let value = dataset.showValues ? max : '';
+      if (dataset.showValues && dataset.unitOfMeasure)
+        value += ' ' + dataset.unitOfMeasure;
+      if (dataset.showValues)
+        value = ' (' + value + ')';
+      const label = (labels && labels[node.key] || node.key) + value;
       let textX = x;
       ctx.fillStyle = dataset.color || 'black';
       ctx.textBaseline = 'middle';
@@ -379,7 +384,7 @@ SankeyController.overrides = {
         },
         label(context) {
           const item = context.dataset.data[context.dataIndex];
-          return item.from + ' -> ' + item.to + ': ' + item.flow;
+          return item.from + ' -> ' + item.to + ': ' + item.flow + ' ' + (context.dataset.unitOfMeasure || '');
         }
       }
     },


### PR DESCRIPTION
Added showValues and unitOfMeasure options: 
`datasets: [
                {
                    data: [{ from: 'TEST1', to: 'TEST2', flow: 15}, {from: 'TEST3', to: 'TEST2', flow: 20}, {from: 'TEST4', to: 'TEST2', flow: 25}, {from: 'TEST2', to: 'TEST6', flow: 60}, {from: 'TEST5', to: 'TEST6', flow: 10}],
                    showValues: true,
                    unitOfMeasure: "kW",
                    colorFrom: (c) => getColor(c.dataset.data[c.dataIndex].from),
                    colorTo: (c) => getColor(c.dataset.data[c.dataIndex].to),
                    borderWidth: 0,
                    borderColor: 'black',
                }
            ],`

![values_unitsOfMeasurement](https://user-images.githubusercontent.com/17676511/128183055-cba64220-8ad7-4016-aee5-0ad69257f507.png)