### PR TITLE
fix: module definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,12 @@
   "main": "dist/chartjs-chart-sankey.js",
   "module": "dist/chartjs-chart-sankey.esm.js",
   "types": "types/index.esm.d.ts",
+  "exports": {
+    "types": "./types/index.esm.d.ts",
+    "require": "./dist/chartjs-chart-sankey.js",
+    "import": "./dist/chartjs-chart-sankey.esm.js",
+    "script": "./dist/chartjs-chart-sankey.min.js"
+  },
   "scripts": {
     "build": "rollup -c",
     "autobuild": "rollup -c -w",


### PR DESCRIPTION
In projects with `type: "module"` in `package.json`, attempting to import the library with `import { SankeyController, Flow } from "chartjs-chart-sankey";` will throw an error.

`SyntaxError: Export named 'SankeyController' not found in module 'node_modules\chartjs-chart-sankey\dist\chartjs-chart-sankey.js'.`

This PR addresses the module recognition issue by adding `exports` configuration to `package.json`.