### PR TITLE
add support for node label positions, colors, background colors, and more

### DIFF
--- a/types/index.esm.d.ts
+++ b/types/index.esm.d.ts
@@ -46,6 +46,24 @@ declare module 'chart.js' {
     font?: FontSpec /* defaults to chart.options.font */
     padding?: number /* defaults to font.lineHeight / 2 */
 
+    /* Enhanced label configuration */
+    nodeLabels?: {
+      /* Label positioning: 'default' (left/right based on position), 'top', 'bottom' */
+      position?: 'default' | 'top' | 'bottom'
+      /* Padding around the label text */
+      padding?: number
+      /* Text color - can be string, object mapping node names to colors, or function */
+      color?: string | Record<string, string> | ((node: SankeyNode) => string)
+      /* Background color - can be string, object mapping node names to colors, or function */
+      backgroundColor?: string | Record<string, string> | ((node: SankeyNode) => string)
+      /* Border radius for background */
+      borderRadius?: number
+      /* Font configuration */
+      font?: FontSpec
+      /* Display labels */
+      display?: boolean
+    }
+
     parsing: { from: string; to: string; flow: string }
   }
 


### PR DESCRIPTION
This fixes the issue of labels not being configurable. Adds position, padding, color, bg color, etc.

Here is how you can use it:

```
nodeLabels: {
  position: 'top',
  padding: 1,
  color: nodeTextColors,        // { "Node A": "white", "Node B": "#374151" }
  backgroundColor: nodeBackgroundColors, // { "Node A": "#3B82F6", "Node B": "#F59E0B" }
  borderRadius: 3,
  display: true,
  font: { size: 11, weight: 'normal' }
}
```

This was requested by people over the years - and I ran into the issue myself. It's much better to do something like this than try to work around it with html and JS