### PR TITLE
add static node padding option

### DIFF
--- a/src/controller.ts
+++ b/src/controller.ts
@@ -144,6 +144,7 @@ export default class SankeyController extends DatasetController {
       priority: !!this.options.priority,
       height: this.chart.canvas.height,
       nodePadding: this.options.nodePadding,
+      nodePaddingType: this.options.nodePaddingType ?? 'dynamic',
       modeX: this.options.modeX,
     })
 

--- a/types/index.esm.d.ts
+++ b/types/index.esm.d.ts
@@ -41,6 +41,7 @@ declare module 'chart.js' {
     borderWidth?: number /* defaults to 1 */
     nodeWidth?: number /* defaults to 10 */
     nodePadding?: number /* defaults to 10 (pixels) */
+    nodePaddingType?: 'static' | 'dynamic' /* defaults to 'dynamic' */
     color?: string /* defaults to 'black' */
     borderColor?: string /* defaults to 'black' */
     font?: FontSpec /* defaults to chart.options.font */


### PR DESCRIPTION
I don't know if anyone cares about this but I wanted to add a "static node padding mode" where the padding that you put in is the padding that you get.

The reason for this is that in my graph I saw some inconsistencies when I added padding. Some nodes had tons of space, others not so much. The default behavior to calculate the padding is great as a default behavior, but it can get in the way.

Please review this code, edit as needed, and add it if you believe it adds value to the project.  I mainly tested it alongside my other PR regarding the custom labels: https://github.com/kurkle/chartjs-chart-sankey/pull/331 that one is a lot more meaningful.

Usage is simple:
`nodePaddingType: 'static'`

and then make sure you actually put in padding:
`nodePadding: 80,`