### PR TITLE
chore: toolchain parity fixes (sideEffects, commit-msg hook)

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -7,14 +7,14 @@ if printf '%s\n' "$subject" | grep -Eq '^(build|chore|ci|docs|feat|fix|perf|refa
   exit 0
 fi
 
-cat >&2 <<EOF
+cat >&2 <<MESSAGE
 Invalid commit message:
   $subject
 
 Use a semantic commit message, for example:
-  feat: add matrix zoom sample
-  fix(chart): handle hidden scales
-  docs!: update public API docs
-EOF
+  feat: add support for radial scales
+  fix(scale): handle hidden axes
+  docs!: document the new option shape
+MESSAGE
 
 exit 1

--- a/package.json
+++ b/package.json
@@ -94,6 +94,10 @@
     "typecheck": "tsc --noEmit && tsc --noEmit -p tsconfig.test.json && tsc -p tsconfig.json --emitDeclarationOnly && tsc --noEmit -p test/types/",
     "typecheck:docs": "astro check"
   },
+  "sideEffects": [
+    "dist/chartjs-chart-sankey.cjs",
+    "dist/chartjs-chart-sankey.min.js"
+  ],
   "type": "module",
   "types": "dist/index.esm.d.ts",
   "unpkg": "dist/chartjs-chart-sankey.min.js",


### PR DESCRIPTION
## Summary
- Add `sideEffects` to `package.json`, matching `chartjs-chart-treemap`/`chartjs-chart-matrix`, so bundlers know the built UMD/min bundles register side effects with Chart.js and don't tree-shake them away. Verified both listed paths (`dist/chartjs-chart-sankey.cjs`, `dist/chartjs-chart-sankey.min.js`) are actually produced by `npm run build`.
- Replace `.githooks/commit-msg`'s example messages, which referenced `matrix` (copy-paste leftover from another kurkle repo), with the generic examples from the shared toolchain templates.

## Not changed, with findings
- `.githooks/pre-commit`: already runs the same five steps as the shared template (`lint`, `test`, `typecheck`, `build`, `docs`), just without `--if-present` guards. No extra/hidden step to report.
- Docs structure: content already lives under `src/content/docs/*.mdx`, same as treemap/matrix's live content — not a gap. Treemap's top-level `docs/index.md` / `usage.md` / `integration.md` are stale, pre-Astro-migration duplicates not wired into its `astro.config.mjs` or build; they weren't copied here on purpose.
- Docs favicon/logo: `astro.config.mjs` sets `publicDir: './docs/public'`, but sankey has no `docs/public` directory (treemap/matrix each have their own branded `favicon.ico`/`logo.svg`/etc there). This is a real gap, but fixing it needs actual sankey-branded artwork, which isn't something to fabricate as part of this PR — flagging for a follow-up with real assets.

## Test plan
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run build` (confirms both `sideEffects` paths are produced)
- [x] `npm test` and `npm run docs` (ran automatically via the `pre-commit` hook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)