### PR TITLE
chore: group dependabot updates and standardize README badges

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,13 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      dev-dependencies:
+        dependency-type: "development"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      actions:
+        patterns: ["*"]

--- a/README.md
+++ b/README.md
@@ -2,13 +2,12 @@
 
 [Chart.js](https://www.chartjs.org/) **^3.3** module for creating sankey diagrams
 
-![CI](https://github.com/kurkle/chartjs-chart-sankey/workflows/CI/badge.svg)
+[![npm](https://img.shields.io/npm/v/chartjs-chart-sankey.svg)](https://www.npmjs.com/package/chartjs-chart-sankey)
+[![release](https://img.shields.io/github/release/kurkle/chartjs-chart-sankey.svg?style=flat-square)](https://github.com/kurkle/chartjs-chart-sankey/releases/latest)
+![npm bundle size](https://img.shields.io/bundlephobia/min/chartjs-chart-sankey.svg)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=kurkle_chartjs-chart-sankey&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=kurkle_chartjs-chart-sankey)
 [![Coverage](https://sonarcloud.io/api/project_badges/measure?project=kurkle_chartjs-chart-sankey&metric=coverage)](https://sonarcloud.io/summary/new_code?id=kurkle_chartjs-chart-sankey)
-[![npm](https://img.shields.io/npm/v/chartjs-chart-sankey.svg)](https://www.npmjs.com/package/chartjs-chart-sankey)
-[![pre-release](https://img.shields.io/github/v/release/kurkle/chartjs-chart-sankey?include_prereleases&style=flat-square)](https://github.com/kurkle/chartjs-chart-sankey/releases/latest)
 [![documentation](https://img.shields.io/static/v1?message=Documentation&color=informational)](https://chartjs-chart-sankey.pages.dev)
-![npm bundle size](https://img.shields.io/bundlephobia/min/chartjs-chart-sankey.svg)
 ![GitHub](https://img.shields.io/github/license/kurkle/chartjs-chart-sankey.svg)
 
 ## Browser support


### PR DESCRIPTION
## Summary
- `.github/dependabot.yml`: group npm dev-dependency bumps into one PR and github-actions bumps into another, instead of one PR per dependency — matches the grouping being rolled out across kurkle repos.
- `README.md`: standardize the badge row to npm version → release → bundle size → Sonar quality gate → Sonar coverage → documentation → license. Removed the `CI` workflow badge (pointed at a workflow named `CI` that no longer exists since the shared-ci migration; CI now runs as `pr-ci`/`main-ci`, so the badge was broken), and swapped the pre-release badge for a stable release badge.
- No `engines` field added to `package.json` — sankey's published code runs in the browser, not as a Node engine target, so that constraint doesn't apply here (it's going into `configs` and `astro-chartjs-editor` instead).

## Test plan
- [x] `npm run lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)