### PR TITLE
ci: ignore TypeScript major bumps in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,12 @@ updates:
     groups:
       dev-dependencies:
         dependency-type: "development"
+    ignore:
+      # @astrojs/check requires typescript ^5 || ^6, so TS 7 fails npm ci
+      # with ERESOLVE and stalls the whole dev-dependencies group.
+      # Remove this once @astrojs/check supports TypeScript 7.
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
## Summary
- Grouped dependabot PR #426 is stuck: `npm ci` fails with `ERESOLVE` because `@astrojs/check@0.9.10` (the latest published version) declares a peer dependency of `typescript@^5.0.0 || ^6.0.0`, which TypeScript 7 violates. Verified this directly from PR #426's failed `shared-ci / CI` run.
- Add an `ignore` rule for TypeScript major-version bumps to `.github/dependabot.yml`'s npm section, with a comment explaining why and when to remove it. Minor/patch typescript updates are unaffected and still go through the `dev-dependencies` group.
- Did not move `typescript` out of the group instead — that would just produce a separate, permanently-failing TS-only PR.
- Did not force TS 7 via npm `overrides` — `@astrojs/check` uses TypeScript's compiler API directly, so forcing the version would likely break `astro check` for real rather than just silencing the ERESOLVE.

## Test plan
- [x] `npm run lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)