### PR TITLE
ci: pass SONAR_TOKEN explicitly and scan workflow files with Sonar

### DIFF
--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -14,7 +14,8 @@ jobs:
     with:
       fetch-depth: 0
       run-audit-signatures: true
-    secrets: inherit
+    secrets:
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
   release:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -13,7 +13,8 @@ jobs:
     with:
       fetch-depth: 1
       run-audit-signatures: false
-    secrets: inherit
+    secrets:
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
   compressed-size:
     runs-on: ubuntu-latest

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -5,10 +5,17 @@ sonar.organization=kurkle
 sonar.projectName=chartjs-chart-sankey
 
 # Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
-sonar.sources=src/
+sonar.sources=src/,.github/workflows
 sonar.exclusions=**/*.test.*
 
 sonar.tests=test/
 
 # Coverage reports
 sonar.javascript.lcov.reportPaths=coverage/chrome/lcov.info,coverage/firefox/lcov.info,coverage/unit/lcov.info
+
+# The floating v1 tag is deliberate: it is how a fix in kurkle/configs reaches
+# every repository without a pull request in each one. Pinning a commit SHA
+# would defeat that mechanism.
+sonar.issue.ignore.multicriteria=e1
+sonar.issue.ignore.multicriteria.e1.ruleKey=githubactions:S7637
+sonar.issue.ignore.multicriteria.e1.resourceKey=.github/workflows/*.yml


### PR DESCRIPTION
## Summary
- `pr-ci.yml` / `main-ci.yml`: replace `secrets: inherit` with an explicit `secrets: SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}` when calling the shared workflow. `kurkle/configs/.github/workflows/shared-ci.yml@v1` now declares `SONAR_TOKEN` in its `workflow_call.secrets` schema, so only the one secret it actually needs is passed instead of every repo secret. `GITHUB_TOKEN` needs no explicit passing — it's always available.
- `sonar-project.properties`: add `.github/workflows` to `sonar.sources` so the CI workflow YAML is actually scanned, and add an ignore rule for `githubactions:S7637` scoped to `.github/workflows/*.yml`, with a comment explaining that the floating `v1` tag on the shared workflow is intentional (it's how a `configs` fix reaches every repo without a PR in each one — pinning a SHA would defeat that).

## Test plan
- [x] `npm run lint`
- [ ] This PR's own Sonar run analyzes the workflow files and shows neither S7635 nor S7637

🤖 Generated with [Claude Code](https://claude.com/claude-code)