### PR TITLE
ci: install dependencies with --ignore-scripts

### DIFF
--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -38,7 +38,7 @@ jobs:
           cache: npm
 
       - name: Install dependencies
-        run: npm clean-install
+        run: npm clean-install --ignore-scripts
 
       - name: Build
         run: npm run build

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -30,7 +30,7 @@ jobs:
           cache: npm
 
       - name: Install dependencies
-        run: npm clean-install
+        run: npm clean-install --ignore-scripts
 
       - name: Build
         run: npm run build
@@ -41,3 +41,4 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           pattern: "./dist/*.{js,cjs}"
           build-script: "npm run build"
+          install-script: "npm ci --ignore-scripts"


### PR DESCRIPTION
## Summary
- Add `--ignore-scripts` to `npm clean-install` in `main-ci.yml`'s release job and `pr-ci.yml`'s `compressed-size` job, blocking dependency lifecycle scripts (a common supply-chain malware vector).
- Pass `install-script: "npm ci --ignore-scripts"` to `preactjs/compressed-size-action`, since it does its own internal install for both the PR and base branches to diff them.
- `kurkle/configs`'s `shared-ci.yml` sets its own install command separately and is intentionally out of scope here.

Only two packages in this dependency tree ship install scripts, `esbuild` and `@swc/core`. Verified locally (clean `--ignore-scripts` install in a scratch copy, not just trusting it): `npm run build` (uses `@swc/core`), `npm run docs` (Astro/Vite, uses `esbuild`), and the full `npm test` suite (90 unit+fixture specs plus integration tests, exercising `@napi-rs/canvas`'s native binding) all pass — native binaries for these packages come from optional platform packages, not from `postinstall`.

## Test plan
- [x] `npm run lint`
- [x] Clean `--ignore-scripts` install + `npm run build` + `npm run docs` + `npm test`, verified locally in a scratch copy
- [ ] This PR's own CI (release-job path isn't exercised by PR CI, but `compressed-size` job's install is)

🤖 Generated with [Claude Code](https://claude.com/claude-code)