### PR TITLE
fix(docs): add missing favicon.svg to stop 404 on docs site

### DIFF
--- a/docs/public/favicon.svg
+++ b/docs/public/favicon.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" role="img" aria-label="chartjs-chart-sankey">
+  <rect width="32" height="32" rx="6" fill="#14746a"/>
+  <path d="M11 7C16 7 16 6 21 6v8c-5 0-5 1-10 1z" fill="#ffffff" opacity=".72"/>
+  <path d="M11 16c5 0 5 2 10 2v8c-5 0-5-1-10-1z" fill="#ffffff" opacity=".46"/>
+  <rect x="8" y="7" width="3" height="18" fill="#ffffff"/>
+  <rect x="21" y="6" width="3" height="8" fill="#ffffff"/>
+  <rect x="21" y="18" width="3" height="8" fill="#ffffff"/>
+</svg>


### PR DESCRIPTION
## Summary

`astro.config.mjs` sets `publicDir: './docs/public'`, but that directory didn't exist —
sankey is the only one of the three Astro-based repos without it. Starlight links a
default favicon on every page (`<link rel="shortcut icon" href="/favicon.svg" type="image/svg+xml"/>`),
which pointed at nothing. Confirmed in production: `https://chartjs-chart-sankey.pages.dev/favicon.svg` → 404
(compare `https://chartjs-chart-matrix.pages.dev/favicon.ico` → 200).

This PR adds `docs/public/favicon.svg` so the link resolves. No `astro.config.mjs`
changes — Starlight's default already points at `/favicon.svg`, so the file alone is
enough.

**The artwork is a placeholder, not the final look.** It's a simple sankey glyph (one
source node, two flows into two target nodes) in the site's teal. A real favicon/logo
for chartjs-chart-sankey is still an open item on the user's list — this PR only removes
the 404, it does not settle the visual identity. It intentionally does not build out a
full favicon set (`.ico`, apple-touch-icon, webmanifest) the way chartjs-chart-matrix
does — chartjs-chart-treemap doesn't have one either, and the shape of that set hasn't
been decided yet.

## Verification

Ran `npm run docs` and inspected the build output directly (not just a green exit code):

```
$ ls -la dist/docs/favicon.svg
-rw-r--r--@ 1 jkurkela  staff  507 Sep  6 09:58 dist/docs/favicon.svg

$ grep -o '<link[^>]*icon[^>]*>' dist/docs/usage/index.html
<link rel="shortcut icon" href="/favicon.svg" type="image/svg+xml"/>
```

Also ran `npm test`: 90/90 (Chrome + Firefox, 45 each) fixture/unit tests SUCCESS, plus
2/2 browser ESM integration tests, plus Node CommonJS/ESM integration tests (no errors).
The repo's pre-commit hook additionally re-ran lint, typecheck, and the full docs build
on commit — all green; the 4 pre-existing lint complexity warnings in
`src/controller.ts` / `src/lib/layout.ts` are unrelated to this change.

## Out of scope (not fixed, only noting)

- No favicon/logo artwork exists anywhere in the repo (only `test/fixtures/*.png`), so
  the visual identity question is still open.
- Did not touch `docs/styles/starlight.css`, add a README logo, or build `og:image`
  assets — all explicitly out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
