### PR TITLE
docs: slim README to a quickstart, point config reference at the docs site

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # chartjs-chart-sankey
 
-[Chart.js](https://www.chartjs.org/) **^3.3** module for creating sankey diagrams
-
 [![npm](https://img.shields.io/npm/v/chartjs-chart-sankey.svg)](https://www.npmjs.com/package/chartjs-chart-sankey)
 [![release](https://img.shields.io/github/release/kurkle/chartjs-chart-sankey.svg?style=flat-square)](https://github.com/kurkle/chartjs-chart-sankey/releases/latest)
 ![npm bundle size](https://img.shields.io/bundlephobia/min/chartjs-chart-sankey.svg)
@@ -10,165 +8,60 @@
 [![documentation](https://img.shields.io/static/v1?message=Documentation&color=informational)](https://chartjs-chart-sankey.pages.dev)
 ![GitHub](https://img.shields.io/github/license/kurkle/chartjs-chart-sankey.svg)
 
-## Browser support
+[Chart.js](https://www.chartjs.org/) **v3.3+, v4+** module that adds a sankey chart type, drawing flows between named nodes as directional bands whose width is proportional to the flow value — useful for visualizing energy transfers, budgets, funnels, and other flow-style data, for anyone already charting with Chart.js.
 
-All modern and up-to-date browsers are supported, including, but not limited to:
+## Example
 
-- Chrome
-- Edge
-- Firefox
-- Safari
+![Sankey Example Image](test/fixtures/energy.png)
 
-Internet Explorer 11 is not supported.
+## Installation
 
-## Typescript
-
-Typescript 3.x and higher is supported.
-
-## Documentation
-
-You can find documentation for chartjs-chart-sankey at [https://chartjs-chart-sankey.pages.dev/](https://chartjs-chart-sankey.pages.dev/).
-
-## Integration
-
-You can use **chartjs-chart-sankey.js** as ES module. You'll need to manually register two components
-
-```js
-import {Chart} from 'chart.js';
-import {SankeyController, Flow} from 'chartjs-chart-sankey';
-
-Chart.register(SankeyController, Flow);
+```bash
+npm install chartjs-chart-sankey
 ```
 
-For script tag usage, load the browser bundle after Chart.js. The browser bundle registers the sankey controller
-and flow element automatically.
+Or via CDN:
 
 ```html
 <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/chartjs-chart-sankey"></script>
 ```
 
-The same bundle can be loaded from UNPKG:
-
-```html
-<script src="https://unpkg.com/chart.js"></script>
-<script src="https://unpkg.com/chartjs-chart-sankey"></script>
-```
-
-If a CDN does not use the package metadata for its default file, reference the browser bundle directly:
-
-```html
-<script src="https://cdn.jsdelivr.net/npm/chartjs-chart-sankey/dist/chartjs-chart-sankey.min.js"></script>
-```
-
-To create a sankey chart, include chartjs-chart-sankey.js after chart.js and then create the chart by setting the `type`
-attribute to `'sankey'`
+## Quickstart
 
 ```js
-const chart = new Chart(ctx, {
-  type: 'sankey',
-  data: dataObject
-});
-```
+import { Chart, LinearScale } from 'chart.js';
+import { Flow, SankeyController } from 'chartjs-chart-sankey';
 
-## Configuration
+Chart.register(LinearScale, SankeyController, Flow);
 
-Example:
-
-```js
-const colors = {
-  a: 'red',
-  b: 'green',
-  c: 'blue',
-  d: 'gray'
-};
-
-const getHover = (key) => colors[key];
-const getColor = (key) => colors[key];
-
-const chart = new Chart(ctx, {
-  type: 'sankey',
-  data: {
-    datasets: [{
-      label: 'My sankey',
-      data: [
-        {from: 'a', to: 'b', flow: 10},
-        {from: 'a', to: 'c', flow: 5},
-        {from: 'b', to: 'c', flow: 10},
-        {from: 'd', to: 'c', flow: 7}
-      ],
-      colorFrom: (c) => getColor(c.dataset.data[c.dataIndex].from),
-      colorTo: (c) => getColor(c.dataset.data[c.dataIndex].to),
-      hoverColorFrom: (c) => getHover(c.dataset.data[c.dataIndex].from),
-      hoverColorTo: (c) => getHover(c.dataset.data[c.dataIndex].to),
-      colorMode: 'gradient', // or 'from' or 'to'
-      /* optionally override default alpha (0.5) applied to colorFrom and colorTo */
-      alpha: 1,
-      /* optional labels */
-      labels: {
-        a: 'Label A',
-        b: 'Label B',
-        c: 'Label C',
-        d: 'Label D'
-      },
-      /* optional priority */
-      priority: {
-        b: 1,
-        d: 0
-      },
-      /* optional column overrides */
-      column: {
-        d: 1
-      },
-      size: 'max', // or 'min' if flow overlap is preferred
-    }]
-  },
-});
-```
-
-### Custom data structure
-
-Custom data structure can be used by specifying the custom data keys in `options.parsing`.
-For example:
-
-```js
-const chart = new Chart(ctx, {
+new Chart(document.getElementById('chart'), {
   type: 'sankey',
   data: {
     datasets: [
       {
+        label: 'My sankey',
         data: [
-          {source: 'a', destination: 'b', value: 20},
-          {source: 'c', destination: 'd', value: 10},
-          {source: 'c', destination: 'e', value: 5},
+          {from: 'a', to: 'b', flow: 10},
+          {from: 'a', to: 'c', flow: 5},
+          {from: 'b', to: 'd', flow: 6},
+          {from: 'c', to: 'd', flow: 4},
         ],
-        colorFrom: 'red',
-        colorTo: 'green'
-      }
-    ]
+      },
+    ],
   },
-  options: {
-    parsing: {
-      from: 'source',
-      to: 'destination',
-      flow: 'value'
-    }
-  }
 });
 ```
 
-## Example
+See more integration options (script tag, other module loaders) in the [documentation](https://chartjs-chart-sankey.pages.dev/integration/).
 
-![Sankey Example Image](test/fixtures/energy.png)
+## Documentation
 
-## Online examples
-
-[codepen](https://codepen.io/kurkle/pen/bGVKPOM)
-[Vue.js 2](https://codesandbox.io/s/reverent-boyd-od2fr?file=/src/App.vue)
+You can find documentation for chartjs-chart-sankey at [https://chartjs-chart-sankey.pages.dev/](https://chartjs-chart-sankey.pages.dev/). The full dataset and options reference lives there, not in this README — this file stays a quickstart.
 
 ## Development
 
-You first need to install node dependencies  (requires [Node.js](https://nodejs.org/)):
+You first need to install node dependencies (requires [Node.js](https://nodejs.org/)):
 
 ```bash
 > npm install
@@ -177,12 +70,10 @@ You first need to install node dependencies  (requires [Node.js](https://nodejs.
 The following commands will then be available from the repository root:
 
 ```bash
-> npm run build         // build dist files
+> npm run build        // build dist files
 > npm run autobuild     // build and watch for changes
 > npm test              // run all tests
-> npm autotest          // run all tests and watch for changes
-> npm lint              // perform code linting
-> npm package           // create an archive with dist files and samples
+> npm run lint          // perform code linting
 ```
 
 ## License


### PR DESCRIPTION
## Summary

Part of the fleet-wide README unification: **README stays a thin gateway to the docs site**, not a duplicate of it. This repo's README had grown to 191 lines, the longest in the fleet, mostly because its `## Configuration` section duplicated the whole dataset/options reference that already lives on the docs site's `/usage/` page. Two copies of the same reference drift apart over time.

Rewritten to the skeleton chartjs-chart-matrix and chartjs-chart-treemap already use (both on `main`): badges, one description paragraph, Example, Installation, Quickstart, Documentation, Development, License. 191 → 82 lines.

## What changed, and why

### Removed `## Configuration` and `### Custom data structure`

Checked first that everything in them is actually covered on the site before deleting anything — this was the point of the exercise, not a formality:

| README config content | On the site? | Where |
|---|---|---|
| `colorFrom`, `colorTo` | Yes | `/usage/` option table |
| `colorMode: 'gradient'/'from'/'to'` | Yes | `/usage/` option table |
| `labels` | Yes | `/usage/` option table |
| `priority` | Yes | `/usage/` option table |
| `column` | Yes | `/usage/` option table |
| `nodeWidth`, `nodePadding` | Yes | `/usage/` option table |
| Custom data structure (`options.parsing` with custom `from`/`to`/`flow` keys) | Yes | `samples/parsing` — the exact `source`/`destination`/`value` shape from the README, runnable |
| `hoverColorFrom`, `hoverColorTo` | **No** | not in `/usage/`'s table or any sample |
| `alpha` (default `0.5`, blends `colorFrom`/`colorTo`) | **No** | not in `/usage/`'s table or any sample |

**The last two rows are real, currently-supported options** (`src/flow.ts` defaults: `alpha: 0.5`, `hoverColorFrom`/`hoverColorTo` scriptable, confirmed in `src/types.ts` and covered by `src/flow.test.ts`) that this PR does not remove documentation for anywhere — the README's config section is deleted, but the site doesn't have them either. Flagging this rather than either silently dropping the information or duplicating it back into the README: **a separate PR against the docs site should add `alpha` and `hoverColorFrom`/`hoverColorTo` to `/usage/`'s option table.**

### Dropped `## Browser support` and `## Typescript`

Judgment call — neither is on the docs site either, but matrix and treemap both dropped these same two sections with no replacement, and the content itself (no IE11, TS 3.x+) doesn't say anything specific to this package now that both are just the default expectation for anything shipping ES2017+ code with bundled `.d.ts` files. Open to reconsidering if this loses something that mattered.

### Dropped `## Online examples` (a CodePen and a Vue.js 2 CodeSandbox)

Could not confirm either still exists. Both `codepen.io` and `codesandbox.io` front every request (including deliberately-invalid slugs on the same accounts) with an identical Cloudflare "Just a moment..." JS challenge, so a 403 here proves nothing about whether the specific pen/sandbox is still there — verified by requesting a known-nonexistent URL on both hosts and getting the same response as the real one. Reporting the limitation instead of asserting either way. Neither matrix nor treemap has this section either.

### Added `## Installation` (npm + CDN) — wasn't its own section before.

### Rewrote `## Quickstart`

Smallest working example: plain `from`/`to`/`flow` data, no scriptable color callbacks (`colorFrom`/`colorTo` default to `red`/`green`, so a minimal example doesn't need them). Registers `LinearScale` alongside `SankeyController`/`Flow`, the same way `src/content/docs/integration.mdx` and `test/integration/node-module/test.mjs` already do — omitting it throws `"linear" is not a registered scale"` (checked both ways, see Verification).

### Corrected the Chart.js version claim

`"^3.3"` → `"v3.3+, v4+"`, matching `package.json`'s actual `peerDependencies` (`">=3.3.0"`) and sibling repos' phrasing.

### Development section

Now lists only scripts that exist in `package.json` (`build`, `autobuild`, `test`, `lint`). The previous version referenced `npm autotest` and `npm package`, neither of which exists in this repo. **Neither exists in matrix's or treemap's `package.json` either**, despite both of their (already-unified) READMEs listing an equivalent `npm package` line, and treemap's README additionally mis-describes its own `npm run dev` as "build and watch for changes" when it actually starts the Karma test watcher (`rollup -c -w`, i.e. `autobuild`, is the one that builds and watches). Not fixing those two repos here — flagging for whoever picks up their icon/README follow-ups.

## Verification

- Every code block is either copied from a verified source or actually run — noted per block:
  - Quickstart: **run**. Extracted the exact code block from `README.md` with a script (not retyped) and executed it against the built `dist/chartjs-chart-sankey.esm.js` in Node with `@napi-rs/canvas`, swapping only the `document.getElementById('chart')` DOM lookup for a canvas context (everything else — imports, `Chart.register`, the chart config — is untouched). Produced a real rendered sankey (non-blank, correct node/flow layout). Also confirmed that dropping `LinearScale` from the same script reproduces `"linear" is not a registered scale"`.
  - Installation / CDN snippets: copied from the existing, already-shipping `docs/content/docs/integration.mdx` and prior README (unchanged commands), and the CDN URLs themselves were fetched live (200 for all of `cdn.jsdelivr.net/npm/chart.js`, `.../chartjs-chart-sankey`, `.../chartjs-chart-sankey/dist/chartjs-chart-sankey.min.js`, `unpkg.com/chart.js`, `unpkg.com/chartjs-chart-sankey`).
- Every link fetched:
  - `chartjs-chart-sankey.pages.dev`, `/usage/`, `/integration/` → 200
  - `github.com/kurkle/chartjs-chart-sankey/releases/latest` → 302 (redirect to the tag, not a 404)
  - `opensource.org/licenses/MIT`, `nodejs.org` → 200 after redirect
  - `npmjs.com/package/chartjs-chart-sankey` → 403 to curl/WebFetch (npmjs.com blocks non-browser clients broadly; same URL pattern matrix/treemap already use)
- Every badge fetched and checked for a real value, none "unknown":
  - npm: `v0.15.3`, release: `v0.15.3`, license: `MIT`
  - SonarCloud quality gate: `passed`, coverage: `87%`
  - `npm bundle size` (bundlephobia): rate-limited by upstream — known, already-accepted fleet limitation (not something this PR changes)
- `npm test`: 90/90 unit+fixture (Chrome + Firefox, 45 each), 2/2 browser ESM integration, Node CommonJS/ESM integration tests all passing.
- Pre-commit hook re-ran lint, test, typecheck, build, and docs build on commit — all green (lint's 4 warnings are pre-existing cognitive-complexity notices in `src/controller.ts`/`src/lib/layout.ts`, unrelated to this change).

## Scope

Only `README.md`. Nothing in `docs/`, `astro.config.mjs`, or the icon set touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
