### PR TITLE
docs: document hoverColorFrom, hoverColorTo, and alpha

### DIFF
--- a/src/content/docs/usage.mdx
+++ b/src/content/docs/usage.mdx
@@ -36,8 +36,20 @@ Sankey data points define directed flows between named nodes.
       <td>Scriptable color for the target node side.</td>
     </tr>
     <tr>
+      <td><code>hoverColorFrom</code></td>
+      <td>Scriptable hover color for the source node side. Defaults to <code>colorFrom</code> saturated and darkened.</td>
+    </tr>
+    <tr>
+      <td><code>hoverColorTo</code></td>
+      <td>Scriptable hover color for the target node side. Defaults to <code>colorTo</code> saturated and darkened.</td>
+    </tr>
+    <tr>
       <td><code>colorMode</code></td>
       <td>Flow coloring mode: <code>gradient</code>, <code>from</code>, or <code>to</code>.</td>
+    </tr>
+    <tr>
+      <td><code>alpha</code></td>
+      <td>Opacity applied to <code>colorFrom</code> and <code>colorTo</code> when rendering a flow. Not scriptable. Defaults to <code>0.5</code>.</td>
     </tr>
     <tr>
       <td><code>labels</code></td>
@@ -77,6 +89,8 @@ Sankey data points define directed flows between named nodes.
     </tr>
   </tbody>
 </table>
+
+`hoverColorFrom` and `hoverColorTo` are never simply unset: leaving them out doesn't turn off the hover effect, it falls back to a computed color — `colorFrom`/`colorTo` run through Chart.js's own `getHoverColor` helper (saturated by 0.5, darkened by 0.1). To get no color change on hover, set `hoverColorFrom`/`hoverColorTo` explicitly to the same value as `colorFrom`/`colorTo`.
 
 ## Node Labels
 


### PR DESCRIPTION
## Summary

While slimming the README in #435, its `## Configuration` section was checked against the docs site before deletion. Everything in it turned out to be covered on the site — except `hoverColorFrom`, `hoverColorTo`, and `alpha`. Those are real, typed, tested dataset options with no documentation anywhere once that README section was gone:

```
$ git grep -n "hoverColorFrom\|hoverColorTo\|alpha" -- src/flow.ts src/types.ts src/flow.test.ts src/content/docs/
src/flow.ts:44:const applyAlpha = ...
src/flow.ts:136:    alpha: 0.5,
src/flow.ts:148:    hoverColorFrom: (_ctx, options) => getHoverColorOption(options.colorFrom),
src/flow.ts:149:    hoverColorTo: (_ctx, options) => getHoverColorOption(options.colorTo),
src/types.ts:57:  alpha?: number
src/types.ts:68:  hoverColorFrom?: ScriptableAndArray<Color, SankeyScriptableContext>
src/types.ts:69:  hoverColorTo?: ScriptableAndArray<Color, SankeyScriptableContext>
src/flow.test.ts:30,42,43: (test coverage for all three)
# (nothing under src/content/docs/)
```

This adds them to `src/content/docs/usage.mdx`'s Common Dataset Options table, so slimming the README doesn't leave these three as documented-nowhere options.

## What was added, read from source (not the deleted README text, not memory)

- **`alpha`** — `src/types.ts:57` types it as a plain `number` on `SankeyControllerDatasetOptions` (not `ScriptableAndArray`, unlike `colorFrom`/`colorTo`/`hoverColorFrom`/`hoverColorTo` — it is **not scriptable**). `src/flow.ts`'s `Flow.defaults` sets it to `0.5`, and `setStyle()` applies it via `applyAlpha()` to `colorFrom`/`colorTo` in every `colorMode` branch (`from`, `to`, and the gradient case). Added as a table row, explicitly marked not scriptable, default `0.5`.

- **`hoverColorFrom` / `hoverColorTo`** — `src/types.ts:68-69` types both as `ScriptableAndArray<Color, SankeyScriptableContext>`, identically to `colorFrom`/`colorTo`. Their *defaults* in `src/flow.ts` are not static colors but functions — `(_ctx, options) => getHoverColorOption(options.colorFrom)` (and the `colorTo` equivalent) — and `getHoverColorOption` forwards non-string values through unchanged, or for string colors calls Chart.js's own `getHoverColor` helper (`chart.js/dist/chunks/helpers.dataset.js`: `saturate(0.5).darken(0.1)`). So **leaving them unset does not mean "no hover effect"** — it means a computed variant of `colorFrom`/`colorTo`. Added table rows plus a short paragraph after the table spelling this out; a bare "Scriptable hover color..." row wouldn't have surfaced the empty-vs-missing distinction (raised by the coordinator, and I agree a one-line cell doesn't carry it — the reader needs to know unset ≠ off).

No discrepancy between the (now-removed) README text and the source for either option's default — the numbers and behavior documented here match what the README said before #435 deleted it, so nothing to flag there.

## Where they were placed

Next to `colorFrom`/`colorTo`/`colorMode` in the Common Dataset Options table (same Option/Description column format, `"Scriptable ..."` prefix convention already used by neighboring rows).

## Verification

```
$ git grep -n "hoverColorFrom\|hoverColorTo\|alpha" -- src/content/docs/
src/content/docs/usage.mdx:39:      <td><code>hoverColorFrom</code></td>
src/content/docs/usage.mdx:43:      <td><code>hoverColorTo</code></td>
src/content/docs/usage.mdx:51:      <td><code>alpha</code></td>
src/content/docs/usage.mdx:93:`hoverColorFrom` and `hoverColorTo` are never simply unset: ...
```

```
$ npm run docs
...
[build] 15 page(s) built in 1.02s
[build] Complete!

$ grep -c hoverColorFrom dist/docs/usage/index.html   # 2 (table row + paragraph)
2
$ grep -c hoverColorTo dist/docs/usage/index.html     # 2
2
$ grep -c alpha dist/docs/usage/index.html            # 1 (table row)
1
```
Confirmed these aren't just present in the source `.mdx` — they're in the actually-built HTML output.

`npm test`: 90/90 unit+fixture (Chrome + Firefox, 45 each), 2/2 browser ESM integration, Node CommonJS/ESM integration tests all passing. Pre-commit hook re-ran lint, test, typecheck, build, and docs build — all green (lint's 4 warnings are the same pre-existing cognitive-complexity notices in `src/controller.ts`/`src/lib/layout.ts`, unrelated).

## Scope

Docs only: `src/content/docs/usage.mdx`. No `src/` code changed (even though reading it surfaced the `alpha`/scriptable-type distinction, nothing there needed changing — it already behaves correctly, it just wasn't documented). No README changes — that's PR #435, unaffected by this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
