### PR TITLE
docs: drop deprecated z import and dead extend from content.config.ts

### DIFF
--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -1,13 +1,11 @@
 import { docsLoader } from '@astrojs/starlight/loaders'
 import { docsSchema } from '@astrojs/starlight/schema'
 
-import { defineCollection, z } from 'astro:content'
+import { defineCollection } from 'astro:content'
 
 const docs = defineCollection({
   loader: docsLoader(),
-  schema: docsSchema({
-    extend: z.object({}),
-  }),
+  schema: docsSchema(),
 })
 
 export const collections = { docs }


### PR DESCRIPTION
## Summary

`src/content.config.ts` imported `z` from `astro:content`:

```ts
import { defineCollection, z } from 'astro:content'
```

`z` there is deprecated (astro's own type definitions carry `@deprecated` on that export) and is being removed in Astro 8.

Its only use in this file was `extend: z.object({})` — an empty-object schema extension. That adds no fields and changes nothing about the schema, so this wasn't a real use of `z` that needed migrating to `astro/zod` — it was dead code that happened to be riding along with the deprecated import. Removed both together rather than swapping the import path.

```diff
-import { defineCollection, z } from 'astro:content'
+import { defineCollection } from 'astro:content'

 const docs = defineCollection({
   loader: docsLoader(),
-  schema: docsSchema({
-    extend: z.object({}),
-  }),
+  schema: docsSchema(),
 })
```

`defineCollection` is unaffected — the deprecation was only on `z`.

This repo is the fleet's reference implementation for `content.config.ts`: two new sites (autocolors, gradient) are being built by mirroring it, so it needs to be correct for whoever copies it next. Kept the file otherwise exactly as it was — no `/// <reference ...>` lines added, unlike matrix/treemap's copies, per instruction to change only the import and schema.

## Verification

```
$ npm run typecheck:docs   # astro check
...
Result (9 files):
- 0 errors
- 0 warnings
- 0 hints
```
Same result before and after (0/0/0) — the deprecation is a TS `@deprecated` JSDoc tag, not something `astro check`'s diagnostics surface as a warning on its own, so the meaningful check is that the import is simply gone: `grep -n "astro:content" src/content.config.ts` now shows only `defineCollection`, no `z`.

```
$ npm run docs
...
[build] 15 page(s) built in 1.24s
[build] Complete!
```
Same page count as every other build this session (15) — no content lost from removing the no-op `extend`.

`npm test`: 90/90 unit+fixture (Chrome + Firefox, 45 each), 2/2 browser ESM integration, Node CommonJS/ESM integration tests all passing. Pre-commit hook re-ran lint, test, typecheck, build, and docs build — all green (lint's 4 warnings are the same pre-existing cognitive-complexity notices in `src/controller.ts`/`src/lib/layout.ts`, unrelated).

## Other deprecations noticed

None. Checked for other `astro:content` imports across the repo (`grep -rln "from 'astro:content'"`) — this is the only file that imports from it, and it's clean now. Not going further than that scan since it wasn't asked for and this PR's scope is this one file.

## Scope

Only `src/content.config.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
