### PR TITLE
docs: point ecosystem links at autocolors and gradient's new docs sites

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -77,11 +77,11 @@ export default defineConfig({
             },
             {
               label: 'chartjs-plugin-autocolors',
-              link: 'https://github.com/kurkle/chartjs-plugin-autocolors',
+              link: 'https://chartjs-plugin-autocolors.pages.dev/',
             },
             {
               label: 'chartjs-plugin-gradient',
-              link: 'https://github.com/kurkle/chartjs-plugin-gradient',
+              link: 'https://chartjs-plugin-gradient.pages.dev/',
             },
           ],
           label: 'Ecosystem',


### PR DESCRIPTION
## Summary

chartjs-plugin-autocolors and chartjs-plugin-gradient each got their own docs.pages.dev site today, the same as matrix and treemap already have. The `Ecosystem` sidebar block in `astro.config.mjs` still pointed both at their GitHub repos instead, unlike the matrix/treemap entries sitting right next to them in the same list.

```diff
             {
               label: 'chartjs-plugin-autocolors',
-              link: 'https://github.com/kurkle/chartjs-plugin-autocolors',
+              link: 'https://chartjs-plugin-autocolors.pages.dev/',
             },
             {
               label: 'chartjs-plugin-gradient',
-              link: 'https://github.com/kurkle/chartjs-plugin-gradient',
+              link: 'https://chartjs-plugin-gradient.pages.dev/',
             },
```

`Awesome Chart.js` is left as-is — it's a GitHub repo (`chartjs/awesome`), not a docs site, so it has nothing to point at instead.

## Verification

Both new URLs fetched live before making the change:
```
$ curl -sL -o /dev/null -w "%{http_code}\n" https://chartjs-plugin-autocolors.pages.dev/
200
$ curl -sL -o /dev/null -w "%{http_code}\n" https://chartjs-plugin-gradient.pages.dev/
200
```

```
$ npm run docs
...
[build] 15 page(s) built in 1.97s
[build] Complete!
```
Same page count as every other build this session (15).

Sidebar links checked in the actually-built HTML, not just the source config:
```
$ grep -o 'href="[^"]*chartjs-plugin-autocolors[^"]*"' dist/docs/usage/index.html
href="https://chartjs-plugin-autocolors.pages.dev/"
$ grep -o 'href="[^"]*chartjs-plugin-gradient[^"]*"' dist/docs/usage/index.html
href="https://chartjs-plugin-gradient.pages.dev/"
$ grep -o 'href="[^"]*chartjs/awesome[^"]*"' dist/docs/usage/index.html
href="https://github.com/chartjs/awesome"
```

`npm test`: 90/90 unit+fixture (Chrome + Firefox, 45 each), 2/2 browser ESM integration, Node CommonJS/ESM integration tests all passing. Pre-commit hook re-ran lint, test, typecheck, build, and docs build — all green (lint's 4 warnings are the same pre-existing cognitive-complexity notices, unrelated).

## Other stale links checked

Scanned for other `github.com/kurkle/...` references in `astro.config.mjs`, `README.md`, and `src/content/docs/` before scoping this to just the two lines above. Everything else pointing at `github.com/kurkle` is this repo's own — the release badge, the chart editor's `sourceBaseUrl`, and the GitHub social icon link — not a cross-repo ecosystem link, so nothing else to change here.

## Scope

Only the two `link` values in `astro.config.mjs`'s Ecosystem block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
