### PR TITLE
ci: move Cloudflare Pages docs deploy to configs' shared workflow

### DIFF
--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -25,6 +25,9 @@ jobs:
       id-token: write
       issues: write
       pull-requests: write
+    outputs:
+      released: ${{ steps.release-version.outputs.released }}
+      version: ${{ steps.release-version.outputs.version }}
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -61,36 +64,14 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Resolved released version: $VERSION"
 
-      - name: Update Cloudflare Pages production docs version
-        if: steps.release-version.outputs.released == 'true'
-        env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          CLOUDFLARE_PAGES_PROJECT: ${{ secrets.CLOUDFLARE_PAGES_PROJECT }}
-          DOCS_VERSION: ${{ steps.release-version.outputs.version }}
-        run: |
-          curl --fail --silent --show-error \
-            --request PATCH \
-            --url "https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/pages/projects/${CLOUDFLARE_PAGES_PROJECT}" \
-            --header "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
-            --header 'Content-Type: application/json' \
-            --data @- <<EOF
-          {
-            "deployment_configs": {
-              "production": {
-                "env_vars": {
-                  "DOCS_VERSION": {
-                    "type": "plain_text",
-                    "value": "${DOCS_VERSION}"
-                  }
-                }
-              }
-            }
-          }
-          EOF
-
-      - name: Trigger Cloudflare Pages production deploy
-        if: steps.release-version.outputs.released == 'true'
-        env:
-          CLOUDFLARE_PAGES_DEPLOY_HOOK: ${{ secrets.CLOUDFLARE_PAGES_DEPLOY_HOOK }}
-        run: curl --fail --silent --show-error --request POST "$CLOUDFLARE_PAGES_DEPLOY_HOOK"
+  docs-deploy:
+    needs: release
+    if: needs.release.outputs.released == 'true'
+    uses: kurkle/configs/.github/workflows/docs-deploy.yml@v1
+    with:
+      version: ${{ needs.release.outputs.version }}
+    secrets:
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      CLOUDFLARE_PAGES_PROJECT: ${{ secrets.CLOUDFLARE_PAGES_PROJECT }}
+      CLOUDFLARE_PAGES_DEPLOY_HOOK: ${{ secrets.CLOUDFLARE_PAGES_DEPLOY_HOOK }}


### PR DESCRIPTION
## Summary

The Cloudflare Pages docs-promotion block (resolve released version, PATCH the production docs version, POST the deploy hook — ~40 lines inside the `release` job) was copied byte-for-byte across matrix, sankey, and treemap's `main-ci.yml`, about to become five repos with autocolors and gradient. `@kurkle/configs@v1` now publishes it as a reusable workflow, `docs-deploy.yml`, called from a repo's own `release` job.

Only the two Cloudflare steps move out. `Resolve released version` (and everything before it — checkout, build, `npx semantic-release`) stays in this file: that job's workflow **file name** is load-bearing for npm's trusted publishing, which binds the publisher identity to `main-ci.yml`. Moving the release step into a called workflow would change that identity and break npm publishing fleet-wide — this repo's `release` job is untouched other than gaining an `outputs:` block.

## The three changes, exactly as documented

Read from `kurkle/configs`' README `## Docs deploy workflow` section (`gh api repos/kurkle/configs/contents/README.md`) and cross-checked against [configs#22](https://github.com/kurkle/configs/pull/22), which states the migration guide was worked out as an actual diff against this repo's `main-ci.yml` specifically.

1. **Job-level `outputs:`** on `release`, next to `permissions:`, before `steps:` — `needs.release.outputs.*` requires job outputs; only the `release-version` *step* published `released`/`version` before.
2. **Removed** the `Update Cloudflare Pages production docs version` and `Trigger Cloudflare Pages production deploy` steps. `Resolve released version` (`id: release-version`) stays.
3. **Added** a `docs-deploy` job calling `kurkle/configs/.github/workflows/docs-deploy.yml@v1`, gated on `needs.release.outputs.released == 'true'`, passing the four Cloudflare secrets by name (not `secrets: inherit`, keeping `NPM_TOKEN` out of a workflow that never touches npm).

96 lines → 77 (14 insertions, 33 deletions, net −19).

## Verification

- **`v1` really points where the guide assumes**: `gh api repos/kurkle/configs/git/refs/tags/v1` and `.../git/refs/heads/main` resolve to the identical commit SHA (`9bbe1031...`), and `gh api -X GET repos/kurkle/configs/contents/.github/workflows/docs-deploy.yml -f ref=v1` returns the file (confirmed via its blob `sha`).
- **`actionlint`**: clean, both on this file specifically and on the whole `.github/workflows/` tree.
- **Valid YAML**: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/main-ci.yml'))"` parses, `jobs` = `shared-ci`, `release`, `docs-deploy`.
- **The release path is intact**: `grep -n "release-version\|semantic-release" .github/workflows/main-ci.yml` shows both the `id: release-version` step and the `npx --no-install semantic-release` step still in this same file — neither moved.
- **Zero deviation from the configs README's worked example**: pasted the README's exact `outputs:` block and `docs-deploy:` job text and confirmed both appear verbatim (character-for-character) in the resulting file — this is the check the coordinator asked for specifically, since the guide was written against this repo, and it passed with no discrepancy to report.
- Checked for other copies of this Cloudflare block elsewhere in `.github/` (`grep -rln "CLOUDFLARE_PAGES_DEPLOY_HOOK"`): only `main-ci.yml`, as expected — nothing else in this repo needed touching.

`npm test`: 90/90 unit+fixture (Chrome + Firefox, 45 each), 2/2 browser ESM integration, Node CommonJS/ESM integration tests all passing (workflow-only change, included as the pre-commit hook runs the full suite regardless). `npm run docs`: 15 pages, same as before.

## What can't be verified here

Only exercises on an actual release push to `main`:
- The real Cloudflare API calls (PATCH the production docs version, POST the deploy hook) executing through `docs-deploy.yml` rather than as local steps.
- The `needs.release.outputs.*` wiring resolving correctly from a genuine `semantic-release` run that produces a real git tag (this only proves out at the next actual release, not from a static read of the YAML).

## Scope

Only `.github/workflows/main-ci.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
