### PR TITLE
fix: count upstream and downstream nodes with a per-call visited set

### DIFF
--- a/src/lib/layout.test.ts
+++ b/src/lib/layout.test.ts
@@ -6,6 +6,7 @@ import {
   calculateX,
   calculateYUsingPriority,
   layout,
+  nodeCount,
   returnsToNearerColumn,
 } from './layout.js'
 
@@ -27,6 +28,14 @@ function each(cases: any[][]) {
       it(formatDescription(description, args), () => fn(...args))
     })
   }
+}
+
+function getNode(nodes: Map<string, SankeyNode>, key: string): SankeyNode {
+  const node = nodes.get(key)
+  if (!node) {
+    throw new Error(`Test setup error: node "${key}" not found`)
+  }
+  return node
 }
 
 describe('lib/layout', () => {
@@ -369,6 +378,76 @@ describe('lib/layout', () => {
       }
     )
   })
+  describe('nodeCount', () => {
+    // Diamond (A -> B, A -> C, B -> D, C -> D) with a cycle back into the diamond
+    // (D -> E, E -> B). B and C both flow into D, and D eventually flows back to B,
+    // so a naive traversal must dedupe nodes to terminate and to avoid double counting.
+    const diamondWithCycle = [
+      { flow: 1, from: 'A', to: 'B' },
+      { flow: 1, from: 'A', to: 'C' },
+      { flow: 1, from: 'B', to: 'D' },
+      { flow: 1, from: 'C', to: 'D' },
+      { flow: 1, from: 'D', to: 'E' },
+      { flow: 1, from: 'E', to: 'B' },
+    ]
+
+    it('counts unique downstream nodes across a diamond and a cycle', () => {
+      const nodes = buildNodesFromData(diamondWithCycle, {})
+
+      // A -> B -> D -> E -> (B, already counted) and A -> C -> (D, already counted)
+      // Unique downstream nodes of A via 'to': B, C, D, E => edges counted: B.to(1) + D.to(1) +
+      // E.to(1) + C.to(1) = 4
+      expect(nodeCount(getNode(nodes, 'A').to, 'to')).toBe(4)
+      // B -> D -> E -> (B, already counted): edges counted: D.to(1) + E.to(1) + B.to(1) = 3
+      expect(nodeCount(getNode(nodes, 'B').to, 'to')).toBe(3)
+      // C -> D -> E -> B -> (D, already counted): edges counted: D.to(1) + E.to(1) + B.to(1) = 3
+      expect(nodeCount(getNode(nodes, 'C').to, 'to')).toBe(3)
+    })
+
+    it('returns the same result for the same list no matter how many unrelated nodeCount calls ran in between', () => {
+      // Regression test for a counter that used to be shared across all nodeCount calls
+      // (module-level, wrapping at 101) to mark visited nodes. In a real layout, sorting a
+      // node's `from`/`to` list calls nodeCount twice per comparison, so a chart with a few
+      // dozen nodes easily produces more than 101 calls in a single layout pass. When the
+      // counter wrapped back to a value still stamped on a node from an earlier, unrelated
+      // call, that node was wrongly treated as "already visited" and dropped from the count.
+      const nodes = buildNodesFromData(
+        [
+          ...diamondWithCycle,
+          // Unrelated filler edges that share no nodes with the diamond/cycle above. Calling
+          // nodeCount on these between the assertions below advances the old module-level
+          // counter without ever touching B, C, D or E.
+          ...Array.from({ length: 40 }, (_, i) => ({ flow: 1, from: `F${i}`, to: `G${i}` })),
+        ],
+        {}
+      )
+      const b = getNode(nodes, 'B')
+      const c = getNode(nodes, 'C')
+      const fillers = Array.from({ length: 40 }, (_, i) => getNode(nodes, `F${i}`))
+
+      const runFillers = (count: number) => {
+        for (let i = 0; i < count; i++) {
+          nodeCount(fillers[i % fillers.length].to, 'to')
+        }
+      }
+
+      const bResults: number[] = []
+      const cResults: number[] = []
+      // Two full rounds of 100 unrelated calls around each probe: comfortably more than 200
+      // nodeCount invocations in total, guaranteed to wrap the old 101-value counter at least
+      // once between probes of the same list.
+      for (let round = 0; round < 2; round++) {
+        bResults.push(nodeCount(b.to, 'to'))
+        runFillers(100)
+        cResults.push(nodeCount(c.to, 'to'))
+        runFillers(100)
+      }
+
+      expect(bResults).toEqual([3, 3])
+      expect(cResults).toEqual([3, 3])
+    })
+  })
+
   describe('addPadding', () => {
     it('when there is a single row of nodes, it should not add any paddings', () => {
       const nodes = [

--- a/src/lib/layout.ts
+++ b/src/lib/layout.ts
@@ -137,27 +137,20 @@ export function calculateX(
   return maxX
 }
 
-// @todo: this will break when there are multiple charts
-let prevCountId = -1
-function getCountId() {
-  prevCountId = prevCountId < 100 ? prevCountId + 1 : 0
-  return prevCountId
-}
-
 type FlowDirection = 'from' | 'to'
 
-function nodeCount(
+export function nodeCount(
   list: Array<FromToElement>,
   prop: FlowDirection,
-  countId = getCountId()
+  seen: Set<SankeyNode> = new Set()
 ): number {
   let count = 0
   for (const elem of list) {
-    if (elem.node._visited === countId) {
+    if (seen.has(elem.node)) {
       continue
     }
-    elem.node._visited = countId
-    count += elem.node[prop].length + nodeCount(elem.node[prop], prop, countId)
+    seen.add(elem.node)
+    count += elem.node[prop].length + nodeCount(elem.node[prop], prop, seen)
   }
   return count
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -101,7 +101,6 @@ export interface SankeyNode {
   y?: number
   x?: number
   color?: Color
-  _visited?: number
 }
 
 export interface SankeyParsedData {


### PR DESCRIPTION
## Cause

`nodeCount()` in `src/lib/layout.ts` marked visited nodes by stamping `node._visited = countId`, where `countId` came from a module-level counter (`getCountId`) that wrapped at 101 (`prevCountId < 100 ? prevCountId + 1 : 0`), with a `// @todo: this will break when there are multiple charts` acknowledging the design flaw.

`flowByNodeCount` calls `nodeCount` twice per `Array.prototype.sort` comparison, so a chart with a few dozen nodes easily produces more than 101 `nodeCount` calls within a single layout pass. When the counter wrapped back to a value still stamped on a node from an earlier, unrelated call, that node was wrongly treated as "already visited" and dropped from the count — silently undercounting and making the sort order (and therefore the layout) depend on how many comparisons the JS engine's sort happened to perform.

## Fix

Replaced the shared counter/`_visited` field with a `Set<SankeyNode>` allocated fresh per outer `nodeCount()` call and threaded through the recursion — the same pattern already used by `getAllKeysForward`. `nodeCount` is now exported (it wasn't before) so it can be unit tested directly. Removed `getCountId`, `prevCountId`, the `_visited` field from `SankeyNode` (`src/types.ts`), and the `@todo` comment. `flowByNodeCount`'s comparison logic is unchanged.

## Test

Added two tests to `src/lib/layout.test.ts`:
- `counts unique downstream nodes across a diamond and a cycle`: builds a graph with a diamond (A→B, A→C, B→D, C→D) and a cycle back into it (D→E, E→B), and asserts exact `nodeCount` values for a few nodes.
- `returns the same result for the same list no matter how many unrelated nodeCount calls ran in between`: interleaves probes of `nodeCount(B.to, 'to')` / `nodeCount(C.to, 'to')` with over 200 total `nodeCount` calls on unrelated filler edges that never touch the shared downstream nodes — enough to wrap the old 101-value counter — and asserts every probe returns the same value.

Verified red on the old code: reproduced the bug standalone (Node script) with a hand-derived diamond+cycle graph, confirming that probing `B.to`/`C.to` interleaved with ~100 unrelated `nodeCount` calls flips the result between the correct value (3) and 0. Then, with only the `export` keyword added to the untouched buggy `nodeCount` (no logic changes), the added "same call gives the same result" test failed exactly as predicted:
```
AssertionError: expected [ 3, +0 ] to deeply equal [ 3, 3 ]
- Expected
+ Received
  [
    3,
-   3,
+   0,
  ]
```
With the real fix restored, `npm run test:unit` passes 59/59 (57 pre-existing + 2 new).

## Fixture result

`npm run test:fixture` (Chromium + Firefox, 46 tests each = 92 total): all pass, and `git status` shows no changes under `test/fixtures/` — no reference PNG was affected by this change in either browser.

## Checks

`npm run format`, `npm run lint` (same 4 pre-existing complexity warnings, none new), `npm run typecheck`, `npm run test:unit`, `npm run test:fixture` all pass. No `dist/` or `package.json` changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)