### PR TITLE
fix: measure nodePadding in CSS pixels instead of device pixels

### DIFF
--- a/src/content/docs/usage.mdx
+++ b/src/content/docs/usage.mdx
@@ -77,7 +77,7 @@ Sankey data points define directed flows between named nodes.
     </tr>
     <tr>
       <td><code>nodePadding</code></td>
-      <td>Padding between nodes within a column.</td>
+      <td>Padding between nodes within a column, in CSS pixels.</td>
     </tr>
     <tr>
       <td><code>orientation</code></td>

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -338,7 +338,7 @@ export default class SankeyController extends DatasetController {
     this._nodes = nodes
 
     const { maxX, maxY } = layout(nodes, sankeyData, {
-      height: orientation === 'vertical' ? this.chart.canvas.width : this.chart.canvas.height,
+      height: orientation === 'vertical' ? this.chart.width : this.chart.height,
       modeX: this.options.modeX,
       nodePadding: this.options.nodePadding ?? 10,
       priority: !!this.options.priority,

--- a/src/lib/layout.ts
+++ b/src/lib/layout.ts
@@ -442,7 +442,7 @@ export function sortFlows(nodeArray: SankeyNode[]) {
 interface LayoutOptions {
   /** use node priority when sorting nodes vertically */
   priority: boolean
-  /** canvas height (in pixels) */
+  /** chart height in CSS pixels */
   height: number
   /** vertical padding between nodes (in pixels) */
   nodePadding: number

--- a/test/specs/node-padding.spec.js
+++ b/test/specs/node-padding.spec.js
@@ -1,0 +1,56 @@
+import { acquireChart } from '../utils'
+
+// Same energy data as resize.spec.js: column 0 has five nodes (Oil, Natural
+// gas, Coal, Nuclear, Renewables), so nodePadding gaps actually show up.
+const data = [
+  { flow: 15, from: 'Oil', to: 'Fossil fuels' },
+  { flow: 20, from: 'Natural gas', to: 'Fossil fuels' },
+  { flow: 25, from: 'Coal', to: 'Fossil fuels' },
+  { flow: 60, from: 'Fossil fuels', to: 'Energy' },
+  { flow: 10, from: 'Nuclear', to: 'Energy' },
+  { flow: 30, from: 'Renewables', to: 'Energy' },
+  { flow: 40, from: 'Energy', to: 'Electricity' },
+  { flow: 35, from: 'Energy', to: 'Heat' },
+  { flow: 25, from: 'Energy', to: 'Lost' },
+]
+
+function buildSankey(devicePixelRatio) {
+  return acquireChart(
+    {
+      data: {
+        datasets: [{ data, nodePadding: 10 }],
+      },
+      options: {
+        animation: false,
+        devicePixelRatio,
+        maintainAspectRatio: false,
+      },
+      type: 'sankey',
+    },
+    {
+      canvas: { height: 400, width: 800 },
+    }
+  )
+}
+
+describe('nodePadding', () => {
+  it('lays out flows identically regardless of devicePixelRatio (#CSS-pixels)', () => {
+    const chart1x = buildSankey(1)
+    const chart2x = buildSankey(2)
+
+    const flows1x = chart1x.getDatasetMeta(0).data
+    const flows2x = chart2x.getDatasetMeta(0).data
+
+    expect(flows1x.length).toBeGreaterThan(0)
+    expect(flows1x.length).toBe(flows2x.length)
+
+    flows1x.forEach((flow1x, i) => {
+      const flow2x = flows2x[i]
+      expect(flow2x.x, `flow ${i} x`).toBeCloseTo(flow1x.x, 2)
+      expect(flow2x.y, `flow ${i} y`).toBeCloseTo(flow1x.y, 2)
+      expect(flow2x.x2, `flow ${i} x2`).toBeCloseTo(flow1x.x2, 2)
+      expect(flow2x.y2, `flow ${i} y2`).toBeCloseTo(flow1x.y2, 2)
+      expect(flow2x.height, `flow ${i} height`).toBeCloseTo(flow1x.height, 2)
+    })
+  })
+})


### PR DESCRIPTION
## Cause

Chart.js's `retinaScale` sets `canvas.height`/`canvas.width` to `chart.height`/`chart.width` × `devicePixelRatio` and draws through a scaled transform (`ctx.setTransform(dpr, 0, 0, dpr, 0, 0)`). `SankeyController.parseObjectData` fed `layout()` the raw device-pixel `canvas.width`/`canvas.height` as the reference size for converting `nodePadding` into flow units (`padding = (maxY / height) * nodePadding`), so the padding was divided by `devicePixelRatio` too many times.

Measured with Playwright Chromium (Chart.js 4.5.1), an 800×400 CSS px chart, `nodePadding: 10`, gap between two adjacent nodes in column 0:

| devicePixelRatio | measured gap |
|---|---|
| 1 | 8.95 px |
| 2 | 4.69 px |
| 3 | 3.18 px |

(8.95 vs the nominal 10 is the chart-area padding, unrelated to this bug.)

## Fix

`src/controller.ts`: use `this.chart.width` / `this.chart.height` (Chart.js's CSS-pixel size, set in `_resize` before `update`/parse) instead of `this.chart.canvas.width` / `this.chart.canvas.height` (device pixels). `src/lib/layout.ts`: corrected the `LayoutOptions.height` doc comment to say CSS pixels. `src/content/docs/usage.mdx`: documented that `nodePadding` is in CSS pixels.

No other logic changes.

## Test

Added `test/specs/node-padding.spec.js`: builds two otherwise-identical sankey charts (same 800×400 CSS-pixel canvas, same multi-node-per-column energy dataset, `animation: false`) that differ only in `devicePixelRatio` (1 vs 2), and asserts every flow element's `x`, `y`, `x2`, `y2`, `height` are equal (`toBeCloseTo`, 2 decimals) between the two.

Verified red before the fix (temporarily reverted the one-line `controller.ts` change): both Chromium and Firefox failed with
```
AssertionError: flow 0 y: expected 340.71428627714283 to be close to 343.27272781, received difference is 2.5584415328571595, but expected 0.005
```
Verified green after restoring the fix: `Test Files 2 passed (2)` / `Tests 2 passed (2)` (one file per browser).

## Rendering change

On HiDPI displays, node gaps grow to the documented size (roughly doubling at `devicePixelRatio: 2`, tripling at 3). At `devicePixelRatio: 1` nothing changes — confirmed the existing fixture PNGs (rendered at dpr 1) are byte-identical (`git status --short test/fixtures/` empty after the full run).

## Checks

- `npm run format` / `npm run lint`: clean except the 4 pre-existing `noExcessiveCognitiveComplexity` warnings (unrelated functions, not touched by this change).
- `npm run typecheck`: clean.
- `npm run test:unit`: 59 passed.
- `npm run test:fixture` (Chromium + Firefox): 94 passed (92 pre-existing + 1 new spec × 2 browsers), fixture PNGs unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)